### PR TITLE
[DEBUG] Emit warning message when compile

### DIFF
--- a/src/packetio.c
+++ b/src/packetio.c
@@ -74,9 +74,9 @@ ipop_send_thread(void *data)
 
     while (1) {
 #if defined(LINUX) || defined(ANDROID)
-        if ((rcount = read(tap, buf, BUFLEN)) < 0) {
+        if ((rcount = read(tap, buf, BUFLEN-BUF_OFFSET)) < 0) {
 #elif defined(WIN32)
-        if ((rcount = read_tap(win32_tap, (char *)buf, BUFLEN)) < 0) {
+        if ((rcount = read_tap(win32_tap, (char *)buf, BUFLEN-BUF_OFFSET)) < 0) {
 #endif
             fprintf(stderr, "tap read failed\n");
             break;


### PR DESCRIPTION
With most recent GCC library, it emits warning message since the
buffer is smaller than its length. It also seems make runtime
error of __fortify_err.

Both haven't happened before, it occurred after I use Ubuntu
13.10.
