### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ script: make
 compiler:
   - gcc
   - clang
+notifications:
+  irc: "chat.freenode.net#ipop"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+script: make
+compiler:
+  - gcc
+  - clang

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 # build with: make
 # run with:   sudo make exec
-CC=gcc
 MINGWCC=i686-w64-mingw32-gcc
-CFLAGS=-Wall --std=gnu99
+CFLAGS=-Wall -Werror --std=gnu99
 CFLAGS_DEPLOY=-O3
 CFLAGS_DEBUG=-g -O0 -D DEBUG # Include debug symbols, disable optimizations, etc
 SRC_DIR=src


### PR DESCRIPTION
Travis CI is a free continuous integration service. Right now, since our unit tests are broken, this only tests that the code compiles. This lets us avoid breaking the build when accepting pull requests.

Whenever someone opens a pull request, Travis should show if it breaks the build inline with the issue tracker.

I also turned compiler warnings into errors, so Travis will break on those, which means that we need to fix the compiler warning introduced by issue #13 before this is useful.
