### PR TITLE
Update README -- Remove SSL and reference tincan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,35 @@
-IPOP Tap
+IPOP TAP
 ========
 
-This is the tap module for IPOP that performs all packet-level operations,
+This is the TAP module for IPOP that performs all packet-level operations,
 translating packets, setting up, and reading and writing from and to the TAP
 device.
+
+It also serves as a command line tool that can shuttle traffic to and from a TAP
+device through a UDP socket, making it an excellent starting point for
+implementing your own VPN.
 
 How to compile
 --------------
 
+`ipop-tap` isn't generally useful on its own. Typically, [you'll want to build
+it with `ipop-tincan`](https://github.com/ipop-project/documentation/wiki).
+
+These instructions exist for those who wish to use `ipop-tap` on its own as a
+command-line tool, either for testing and development, or for use with some
+other application.
+
+> **warning**
+>
+> This doesn't implement any form of secure authentication or encryption. If you
+> want that, you'll have roll your own, or use it with something else that
+> provides it, such as ipop-tincan.
+
 ### On Debian GNU/Linux (and derivatives)
 
-1.  Check to make sure you have OpenSSL installed (as root):
+1.  Check to make sure you have our build dependencies:
 
-        sudo aptitude install libssl-dev openssl
+        sudo aptitude install build-essential
 
 2.  Build the software (doesn't need root):
 
@@ -24,16 +41,7 @@ How to compile
 
         cd android/jni
 
-2.  Decompress the pre-built libssl and libcrypto binaries:
-
-        gunzip -c libcrypto.a.gz > libcrypto.a
-        gnuzip -c libssl.a.gz > libssl.a
-
-3.  Run the included helper setup script to download the openssl headers:
-
-        ./setup.sh
-
-4.  Use ndk-build (assuming it in your path) to build the application:
+2.  Use ndk-build (assuming it in your path) to build the application:
 
         ndk-build
 
@@ -51,9 +59,3 @@ How to run
 >
 > You can see information on command-line arguments that the program supports by
 > using a `-h` or `--help` flag.
-
-> **warning**
->
-> At the moment this is simply a conceptual prototype, and there is no IPv4
-> encryption in place. We plan to use TLS from OpenSSL, but that's for a future
-> date.


### PR DESCRIPTION
Since the README was last updated, we removed all the SSL code from ipop-tap, and moved it to Tincan. Additionally, building ipop-tap by itself doesn't make much sense anymore for the end user, so I added links to the wiki for building with ipop-tincan.
