### PR TITLE
Move switchmode handling from controllers to TinCan

### DIFF
--- a/src/ipop_tap.c
+++ b/src/ipop_tap.c
@@ -400,7 +400,6 @@ main(int argc, const char *argv[])
     );
 #endif
     opts.translate = 1;
-    opts.switchmode = 0;
     opts.send_func = NULL;
     opts.recv_func = NULL;
 

--- a/src/packetio.c
+++ b/src/packetio.c
@@ -81,6 +81,7 @@ ipop_send_thread(void *data)
     while (1) {
 
         int arp = 0;
+        char * id_key;
 
 #if defined(LINUX) || defined(ANDROID)
         if ((rcount = read(tap, buf, BUFLEN-BUF_OFFSET)) < 0) {
@@ -91,8 +92,74 @@ ipop_send_thread(void *data)
             break;
         }
 
+        ncount = rcount + BUF_OFFSET;
+
+        /*---------------------------------------------------------------------
+        Switchmode
+        ---------------------------------------------------------------------*/
+        if (opts->switchmode) {
+            /* If the frame is broadcast ARP REQ message, it sends the frame to
+               every TinCan links like physical switch does */
+            if (is_arp_req(buf)) {
+                reset_id_table();
+                while( !is_id_table_end() ) {
+                    if ( is_id_exist() )  {
+                        /* TODO It may be better to retrieve the iterator rather
+                           than key string itself.  */
+                        retrieve_id(&id_key);
+                        peerlist_get_by_ids(id_key, &peer);
+                        set_headers(ipop_buf, peerlist_local.id, peer->id);
+                        if (opts->send_func != NULL) {
+                            if (opts->send_func((const char*)ipop_buf, ncount) < 0) {
+                                fprintf(stderr, "send_func failed\n");
+                            }
+                        }
+                    }
+                    increase_id_table_itr();
+                }
+                continue;
+
+            /* Floods ARP response message to every TinCan links.
+               TODO we must change to send ARP response message to a single
+               TinCan link. */
+            } else if (is_arp_resp(buf))  {
+                reset_id_table();
+                while( !is_id_table_end() ) {
+                    if ( is_id_exist() )  {
+                        retrieve_id(&id_key);
+                        peerlist_get_by_ids(id_key, &peer);
+                        set_headers(ipop_buf, peerlist_local.id, peer->id);
+                        if (opts->send_func != NULL) {
+                            printf("sent arp message\n");
+                            if (opts->send_func((const char*)ipop_buf,
+                                                 ncount) < 0) {
+                                fprintf(stderr, "send_func failed\n");
+                            }
+                        }
+                    }
+                    increase_id_table_itr();
+                }
+                continue;
+            }
+
+            /* If the MAC address is in the table, we forward the frame to
+               destined TinCan link */
+            peerlist_get_by_mac_addr(buf, &peer);
+            set_headers(ipop_buf, peerlist_local.id, peer->id);
+            if (opts->send_func != NULL) {
+                if (opts->send_func((const char*)ipop_buf, ncount) < 0) {
+                    fprintf(stderr, "send_func failed\n");
+                }
+            }
+            continue;
+        }
+
+        /*---------------------------------------------------------------------
+        Conventional IPOP Tap (non-switchmode)
+        ---------------------------------------------------------------------*/
+
         // checks to see if this is an ARP request, if so, send response
-        if (buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01 
+        if (buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01
             && !opts->switchmode) {
             if (create_arp_response(buf) == 0) {
 #if defined(LINUX) || defined(ANDROID)
@@ -256,6 +323,14 @@ ipop_recv_thread(void *data)
 
         // read the 20-byte source and dest uids from the ipop header
         get_headers(ipop_buf, source_id, dest_id);
+
+
+        /* ARP message is forwarded from TinCan links. Add the mac
+           to the table  */
+        if (ipop_buf[52] == 0x08 && ipop_buf[53] == 0x06 && 
+            (ipop_buf[61] == 0x02 || ipop_buf[61] == 0x01)) {
+             mac_add(&ipop_buf);
+        }
 
         // perform translation if IPv4 and translate is enabled
         if ((buf[14] >> 4) == 0x04 && opts->translate) {

--- a/src/packetio.c
+++ b/src/packetio.c
@@ -98,41 +98,18 @@ ipop_send_thread(void *data)
         Switchmode
         ---------------------------------------------------------------------*/
         if (opts->switchmode) {
-            /* If the frame is broadcast ARP REQ message, it sends the frame to
-               every TinCan links like physical switch does */
-            if (is_arp_req(buf)) {
+            /* If the frame is broadcast message, it sends the frame to
+               every TinCan links as physical switch does */
+            if (is_broadcast(buf)) {
                 reset_id_table();
                 while( !is_id_table_end() ) {
                     if ( is_id_exist() )  {
                         /* TODO It may be better to retrieve the iterator rather
                            than key string itself.  */
-                        retrieve_id(&id_key);
-                        peerlist_get_by_ids(id_key, &peer);
+                        peer = retrieve_peer();
                         set_headers(ipop_buf, peerlist_local.id, peer->id);
                         if (opts->send_func != NULL) {
                             if (opts->send_func((const char*)ipop_buf, ncount) < 0) {
-                                fprintf(stderr, "send_func failed\n");
-                            }
-                        }
-                    }
-                    increase_id_table_itr();
-                }
-                continue;
-
-            /* Floods ARP response message to every TinCan links.
-               TODO we must change to send ARP response message to a single
-               TinCan link. */
-            } else if (is_arp_resp(buf))  {
-                reset_id_table();
-                while( !is_id_table_end() ) {
-                    if ( is_id_exist() )  {
-                        retrieve_id(&id_key);
-                        peerlist_get_by_ids(id_key, &peer);
-                        set_headers(ipop_buf, peerlist_local.id, peer->id);
-                        if (opts->send_func != NULL) {
-                            printf("sent arp message\n");
-                            if (opts->send_func((const char*)ipop_buf,
-                                                 ncount) < 0) {
                                 fprintf(stderr, "send_func failed\n");
                             }
                         }

--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -40,10 +40,15 @@
 #include "../lib/klib/khash.h"
 
 KHASH_MAP_INIT_STR(pmap, struct peer_state*)
+/* KHASH only use a integer or string as a key
+   We convert 48bit MAC address to 64bit integer as a key */
+KHASH_MAP_INIT_INT64(64, struct peer_state*)
 
 static khash_t(pmap) *id_table;
 static khash_t(pmap) *ipv4_addr_table;
 static khash_t(pmap) *ipv6_addr_table;
+static khash_t(64) *mac_table;
+static khint_t id_iterator;
 static khint_t ipv4_iterator;
 static khint_t ipv6_iterator;
 
@@ -108,6 +113,7 @@ peerlist_init()
     id_table = kh_init(pmap);
     ipv4_addr_table = kh_init(pmap);
     ipv6_addr_table = kh_init(pmap);
+    mac_table = kh_init(64);
     return 0;
 }
 
@@ -282,7 +288,45 @@ peerlist_add(const char *id, const struct in_addr *dest_ipv4,
         kh_del(pmap, ipv6_addr_table, k);
     }
     kh_value(ipv6_addr_table, k) = peer;
+
+
     increment_base_ipv4_addr(); // only actually increment on success
+    return 0;
+}
+
+// Create peer with given uid and make index by uid
+int
+peerlist_add_by_uid(const char *id)
+{
+    // create and populate a peer structure
+    struct peer_state *peer = malloc(sizeof(struct peer_state));
+    if (peer == NULL) {
+        fprintf(stderr, "Not enough memory to allocate peer.\n");
+    }
+    memcpy(peer->id, id, ID_SIZE);
+
+    // Allocate space for our keys:
+    // hsearch requires our keys to be null-terminated strings, so we convert
+    // in_addr and in6_addr values with inet_ntop first, but we need to allocate
+    // space for the keys.
+    const int id_key_length = ID_SIZE * 2 + 1;
+    char *id_key = malloc(id_key_length * sizeof(char));
+
+    int ret;
+    khint_t k;
+
+    // id_table
+    convert_to_hex_string(peer->id, ID_SIZE, id_key, id_key_length);
+    k = kh_put(pmap, id_table, id_key, &ret);
+    if (ret == -1) {
+        fprintf(stderr, "put failed for id_table.\n"); return -1;
+    }
+    else if (!ret) {
+        free(&kh_key(id_table, k));
+        free(kh_value(id_table, k));
+        kh_del(pmap, id_table, k);
+    }
+    kh_value(id_table, k) = peer;
     return 0;
 }
 
@@ -321,6 +365,32 @@ peerlist_add_p(const char *id, const char *dest_ipv4, const char *dest_ipv6,
     return peerlist_add(id, &dest_ipv4_n, &dest_ipv6_n, port);
 }
 
+// Associate mac address with TinCan peer.
+// Fill up MAC address in peer and make index for mac as key and peer as value
+int
+mac_add(const unsigned char * ipop_buf)
+{
+
+    int id_key_length = ID_SIZE*2+1;
+    char id_key [id_key_length];
+    char * mac;
+    int ret;
+    convert_to_hex_string(ipop_buf, ID_SIZE, id_key, id_key_length);
+    struct peer_state *peer = NULL;
+    peerlist_get_by_ids(id_key, &peer);
+    int i;
+    long long key = 0;
+    for(i=0;i<6;i++) {
+        *(peer->mac)=*(ipop_buf+62+i);
+        key += (long long) *(ipop_buf+62+i) << 8*i;
+    }
+    khint_t k = kh_put(64, mac_table, key, &ret);
+    if (ret == -1) {
+        fprintf(stderr, "put failed for mac_table.\n"); return -1;
+    }
+    kh_value(mac_table, k) = peer;
+}
+
 /**
  * Given a unique 160-bit identifier, gives back a pointer to the
  * internal `peer_state` struct representation of the related peer. The
@@ -335,6 +405,16 @@ peerlist_get_by_id(const char *id, struct peer_state **peer)
     char key[id_key_length];
     convert_to_hex_string(id, ID_SIZE, key, id_key_length);
     khint_t k = kh_get(pmap, id_table, key);
+    if (k == kh_end(id_table)) return -1;
+    *peer = kh_value(id_table, k);
+    return 0;
+}
+
+//argument id is give as string
+int
+peerlist_get_by_ids(const char *id, struct peer_state **peer)
+{
+    khint_t k = kh_get(pmap, id_table, id);
     if (k == kh_end(id_table)) return -1;
     *peer = kh_value(id_table, k);
     return 0;
@@ -446,6 +526,22 @@ peerlist_get_by_local_ipv6_addr_p(const char *_local_ipv6_addr,
 }
 
 int
+peerlist_get_by_mac_addr(const unsigned char * buf, struct peer_state **peer)
+{
+    long long key = 0;
+    int i;
+    for(i=0;i<6;i++) {
+        key += (long long) *(buf+i) << 8*i;
+    }
+    khint_t k = kh_get(64, mac_table, key);
+    if (k != kh_end(mac_table) && kh_exist(mac_table, k)) {
+        *peer = kh_value(mac_table, k);
+    }
+    else { *peer = &null_peer; }
+
+}
+
+int
 override_base_ipv4_addr_p(const char *_local_ipv4_addr_p)
 {
     struct in_addr local_ipv4_addr_n;
@@ -485,3 +581,44 @@ check_network_range(struct in_addr ip_addr)
     return 0;
 }
 
+int
+reset_id_table()
+{
+  id_iterator = kh_begin(id_table);
+  return 0;
+}
+
+int
+is_id_table_end()
+{
+  return (id_iterator == kh_end(id_table));
+}
+
+void
+increase_id_table_itr()
+{
+  ++id_iterator;
+}
+
+
+int
+is_id_exist() {
+  return kh_exist(id_table, id_iterator);
+}
+
+void
+retrieve_id(const char ** key)
+{
+   *key = kh_key(id_table, id_iterator);
+}
+
+void
+iterate_id_table()
+{
+    int i=0;
+    for(i=0; i<kh_end(id_table) ; i++) {
+      if (kh_exist(id_table, i)) {
+         printf("i:%d, key:%s\n", i, kh_key(id_table, i));
+      }
+    }
+}

--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -612,6 +612,14 @@ retrieve_id(const char ** key)
    *key = kh_key(id_table, id_iterator);
 }
 
+struct peer_state *
+retrieve_peer()
+{
+    struct peer_state *peer;
+    peer = kh_value(id_table, id_iterator);
+    return peer;
+}
+
 void
 iterate_id_table()
 {

--- a/src/peerlist.h
+++ b/src/peerlist.h
@@ -51,6 +51,7 @@ struct peer_state {
     struct in_addr local_ipv4_addr; // the virtual IPv4 address that we see
     struct in6_addr local_ipv6_addr; // the virtual IPv6 address that we see
     struct in_addr dest_ipv4_addr;  // the actual address to send data to
+    char mac[6]; // MAC address
     uint16_t port; // The open port on the client that we're connected to
 };
 
@@ -78,6 +79,7 @@ WIN32_EXPORT int peerlist_set_local_p(const char *_local_id,
 #endif
 int peerlist_add(const char *id, const struct in_addr *dest_ipv4,
                  const struct in6_addr *dest_ipv6, const uint16_t port);
+int peerlist_add_by_uid(const char *id);
 #if defined(LINUX) || defined(ANDROID)
 int peerlist_add_p(const char *id, const char *dest_ipv4, const char *dest_ipv6,
                    const uint16_t port);
@@ -94,6 +96,7 @@ int peerlist_get_by_local_ipv6_addr(struct in6_addr *_local_ipv6_addr,
                                     struct peer_state **peer);
 int peerlist_get_by_local_ipv6_addr_p(const char *_local_ipv6_addr,
                                       struct peer_state **peer);
+int peerlist_get_by_mac_addr(const unsigned char * buf, struct peer_state **peer);
 int check_network_range(struct in_addr ip_addr);
 
 #if defined(LINUX) || defined(ANDROID)

--- a/src/peerlist.h
+++ b/src/peerlist.h
@@ -98,6 +98,7 @@ int peerlist_get_by_local_ipv6_addr_p(const char *_local_ipv6_addr,
                                       struct peer_state **peer);
 int peerlist_get_by_mac_addr(const unsigned char * buf, struct peer_state **peer);
 int check_network_range(struct in_addr ip_addr);
+struct peer_state * retrieve_peer();
 
 #if defined(LINUX) || defined(ANDROID)
 int override_base_ipv4_addr_p(const char *ipv4);

--- a/src/tap.c
+++ b/src/tap.c
@@ -172,6 +172,12 @@ tap_set_base_flags()
     return tap_set_flags(IFF_NOARP, (short)0);
 }
 
+int
+tap_unset_noarp_flags()
+{
+    return tap_set_flags((short)0, (short) IFF_NOARP);
+}
+
 /**
  * Configures the tap network device to be marked as "UP".
  */

--- a/src/tap.h
+++ b/src/tap.h
@@ -36,6 +36,7 @@ extern "C" {
 
 int tap_open(const char *device, char *mac);
 int tap_set_base_flags();
+int tap_unset_noarp_flags();
 int tap_set_up();
 int tap_set_down();
 int tap_set_mtu(int mtu);

--- a/src/translator.c
+++ b/src/translator.c
@@ -257,4 +257,17 @@ create_arp_response(unsigned char *buf)
     return -1;
 }
 
+int
+is_arp_req(const unsigned char *buf)
+{
+  //if ( buf[0] == 0xff && buf[1] == 0xff && buf[2] == 0xff && buf[3] == 0xff && buf[4] == 0xff && buf[5] == 0xff && buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01 ) {
+  return buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01;
+}
+
+int
+is_arp_resp(const unsigned char *buf)
+{
+  return buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x02;
+}
+
 

--- a/src/translator.c
+++ b/src/translator.c
@@ -258,9 +258,15 @@ create_arp_response(unsigned char *buf)
 }
 
 int
+is_broadcast(const unsigned char *buf)
+{
+  return (buf[0] == 0xff && buf[1] == 0xff && buf[2] == 0xff && 
+          buf[3] == 0xff && buf[4] == 0xff && buf[5] == 0xff);
+}
+
+int
 is_arp_req(const unsigned char *buf)
 {
-  //if ( buf[0] == 0xff && buf[1] == 0xff && buf[2] == 0xff && buf[3] == 0xff && buf[4] == 0xff && buf[5] == 0xff && buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01 ) {
   return buf[12] == 0x08 && buf[13] == 0x06 && buf[21] == 0x01;
 }
 


### PR DESCRIPTION
Sending over traffic intensive packets over socket on tap device was bad idea,
since it cause another fragmentation issue. We move traffic forward layer to
TinCan from controllers. As a first step, we move switchmode handlign from
controller to TinCan.
- in peer_state struct, MAC address field is added.
- mac_table is added, which is for indexing mac address to peer_state
- Now, it is possible to add peer_state with only uid.
