### PR TITLE
switchmode for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BIN_DIR=bin
 LIBS=-lpthread # flags for dynamically linked libraries
 LINUX_FLAGS=-D LINUX
 WIN32_FLAGS=-D WIN32
-WIN32_LDFLAGS=-lws2_32 -lntdll -liphlpapi
+WIN32_LDFLAGS=-lws2_32 -lntdll -liphlpapi -static-libgcc
 
 # create the call to CC needed for a base build
 CC_BUILD=$(CC) $(CFLAGS) $(SRC_DIR)/*.c -I$(SRC_DIR) \

--- a/src/packetio.c
+++ b/src/packetio.c
@@ -81,7 +81,6 @@ ipop_send_thread(void *data)
     while (1) {
 
         int arp = 0;
-        char * id_key;
 
 #if defined(LINUX) || defined(ANDROID)
         if ((rcount = read(tap, buf, BUFLEN-BUF_OFFSET)) < 0) {
@@ -306,7 +305,7 @@ ipop_recv_thread(void *data)
            to the table  */
         if (ipop_buf[52] == 0x08 && ipop_buf[53] == 0x06 && 
             (ipop_buf[61] == 0x02 || ipop_buf[61] == 0x01)) {
-             mac_add(&ipop_buf);
+             mac_add((const unsigned char *) &ipop_buf);
         }
 
         // perform translation if IPv4 and translate is enabled
@@ -345,8 +344,8 @@ ipop_recv_thread(void *data)
         // More accurate implementation would be tap device
         // keeping ARP table or query O/S whether certain mac address is in 
         // network. 
-        if ( opts->switchmode == 0 || 
-             memcmp(buf, buf+6, 6) == 0 && opts->switchmode == 1) { 
+        if ( opts->switchmode == 0 ||
+             (memcmp(buf, buf+6, 6) == 0 && opts->switchmode == 1)) {
             update_mac(buf, opts->mac);
         }
 #if defined(LINUX) || defined(ANDROID)

--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -370,12 +370,11 @@ peerlist_add_p(const char *id, const char *dest_ipv4, const char *dest_ipv6,
 int
 mac_add(const unsigned char * ipop_buf)
 {
-
     int id_key_length = ID_SIZE*2+1;
     char id_key [id_key_length];
-    char * mac;
     int ret;
-    convert_to_hex_string(ipop_buf, ID_SIZE, id_key, id_key_length);
+    convert_to_hex_string((const char *) ipop_buf, ID_SIZE, id_key,
+                          id_key_length);
     struct peer_state *peer = NULL;
     peerlist_get_by_ids(id_key, &peer);
     int i;
@@ -389,6 +388,7 @@ mac_add(const unsigned char * ipop_buf)
         fprintf(stderr, "put failed for mac_table.\n"); return -1;
     }
     kh_value(mac_table, k) = peer;
+    return 0;
 }
 
 /**
@@ -538,7 +538,7 @@ peerlist_get_by_mac_addr(const unsigned char * buf, struct peer_state **peer)
         *peer = kh_value(mac_table, k);
     }
     else { *peer = &null_peer; }
-
+    return 0;
 }
 
 int

--- a/src/peerlist.h
+++ b/src/peerlist.h
@@ -79,15 +79,17 @@ WIN32_EXPORT int peerlist_set_local_p(const char *_local_id,
 #endif
 int peerlist_add(const char *id, const struct in_addr *dest_ipv4,
                  const struct in6_addr *dest_ipv6, const uint16_t port);
-int peerlist_add_by_uid(const char *id);
 #if defined(LINUX) || defined(ANDROID)
 int peerlist_add_p(const char *id, const char *dest_ipv4, const char *dest_ipv6,
                    const uint16_t port);
+int peerlist_add_by_uid(const char *id);
 #elif defined(WIN32)
 WIN32_EXPORT int peerlist_add_p(const char *id, const char *dest_ipv4, 
                                 const char *dest_ipv6, const uint16_t port);
+WIN32_EXPORT int peerlist_add_by_uid(const char *id);
 #endif
 int peerlist_get_by_id(const char *id, struct peer_state **peer);
+int peerlist_get_by_ids(const char *id, struct peer_state **peer);
 int peerlist_get_by_local_ipv4_addr(struct in_addr *_local_ipv4_addr,
                                     struct peer_state **peer);
 int peerlist_get_by_local_ipv4_addr_p(const char *_local_ipv4_addr,
@@ -99,6 +101,13 @@ int peerlist_get_by_local_ipv6_addr_p(const char *_local_ipv6_addr,
 int peerlist_get_by_mac_addr(const unsigned char * buf, struct peer_state **peer);
 int check_network_range(struct in_addr ip_addr);
 struct peer_state * retrieve_peer();
+int reset_id_table();
+int is_id_table_end();
+void increase_id_table_itr();
+int is_id_exist();
+void retrieve_id(const char ** key);
+void iterate_id_table();
+int mac_add(const unsigned char * ipop_buf);
 
 #if defined(LINUX) || defined(ANDROID)
 int override_base_ipv4_addr_p(const char *ipv4);

--- a/src/translator.h
+++ b/src/translator.h
@@ -41,6 +41,13 @@ int translate_packet(unsigned char *buf, const char *source, const char *dest,
 int update_mac(unsigned char *buf, const char* mac);
 
 int create_arp_response(unsigned char *buf);
+
+int is_broadcast(const unsigned char *buf);
+
+int is_arp_req(const unsigned char *buf);
+
+int is_arp_resp(const unsigned char *buf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/win32_tap.c
+++ b/src/win32_tap.c
@@ -146,8 +146,8 @@ get_mac(const char *device_name, char *mac) {
   }
   pCurAddresses = pAddresses;
   while(pCurAddresses) {
-    swprintf(tmp_name, L"%s", pCurAddresses->FriendlyName);
-    swprintf(w_device_name, L"%hs", device_name);
+    swprintf(tmp_name, (int) L"%s", pCurAddresses->FriendlyName);
+    swprintf(w_device_name, (int) L"%hs", (const wchar_t*) device_name);
     if (wcscmp(tmp_name, w_device_name) == 0) {
       memcpy(mac, pCurAddresses->PhysicalAddress, 6);
       result = 1;

--- a/src/win32_tap.c
+++ b/src/win32_tap.c
@@ -146,8 +146,8 @@ get_mac(const char *device_name, char *mac) {
   }
   pCurAddresses = pAddresses;
   while(pCurAddresses) {
-    swprintf(tmp_name, (int) L"%s", pCurAddresses->FriendlyName);
-    swprintf(w_device_name, (int) L"%hs", (const wchar_t*) device_name);
+    swprintf(tmp_name, 100, L"%s", pCurAddresses->FriendlyName);
+    swprintf(w_device_name, 100, L"%hs", device_name);
     if (wcscmp(tmp_name, w_device_name) == 0) {
       memcpy(mac, pCurAddresses->PhysicalAddress, 6);
       result = 1;


### PR DESCRIPTION
Ipoptap.dll file need to export one more function. While compiling it, updated cross compiler MinGW from 4.6 to 4.8 incur many compiling error(originally was warning or notes) messages. These commit resolves these issues. 

Also, the other trivial issue is it seems like one of signature of swprintf is deprecated. 

int swprintf(wchar_t *buffer, size_t count, const wchar_t *format [,argument]...);
int swprintf(wchar_t (&buffer)[size], const wchar_t *format [, argument]...);

We used to use the second one before, but it seems like deprecated so I changed to use the upper one.  I’m not sure what cause this but we could have used the second one in MinGW4.6, but not in MinGW 4.8. 
