### PR TITLE
ARP reply message of Tap itself.

### DIFF
--- a/src/ipop_tap.h
+++ b/src/ipop_tap.h
@@ -50,6 +50,7 @@ typedef struct thread_opts {
     int translate;
     int switchmode;
     char mac[6];
+    char my_ip4[4];
     const char *local_ip4;
     const char *local_ip6;
     int (*send_func)(const char *buf, size_t len);

--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -377,6 +377,9 @@ mac_add(const unsigned char * ipop_buf)
                           id_key_length);
     struct peer_state *peer = NULL;
     peerlist_get_by_ids(id_key, &peer);
+    if (peer == NULL) {
+        fprintf(stderr, "Unable to find the peer with given key.\n"); return -1;
+    }
     int i;
     long long key = 0;
     for(i=0;i<6;i++) {

--- a/src/tap.c
+++ b/src/tap.c
@@ -244,7 +244,7 @@ tap_plen_to_ipv4_mask(unsigned int prefix_len, struct sockaddr *writeback)
  * subnet, aka the routing prefix or the mask length.
  */
 int
-tap_set_ipv4_addr(const char *presentation, unsigned int prefix_len)
+tap_set_ipv4_addr(const char *presentation, unsigned int prefix_len, char * my_ip4)
 {
     struct sockaddr_in socket_address = {
         .sin_family = AF_INET,
@@ -260,6 +260,10 @@ tap_set_ipv4_addr(const char *presentation, unsigned int prefix_len)
     }
     // we have to wrap our sockaddr_in struct into a sockaddr struct
     memcpy(&ifr.ifr_addr, &socket_address, sizeof(struct sockaddr));
+
+    // Copies IPv4 address to my_ip4. IPv4 address starts at sa_data[2] and
+    // terminates at sa_data[5]
+    memcpy(my_ip4, ifr.ifr_addr.sa_data+2,4); 
 
     if (ioctl(ipv4_configuration_socket, SIOCSIFADDR, &ifr) < 0) {
         fprintf(stderr, "Failed to set IPv4 tap device address\n");


### PR DESCRIPTION
In switchmode, when we PING to local/remote tap itself from its clients, it was intermittently not working. The reason was that our tap device does not have feature of making ARP reply message and sends back to the source. But, PINGing to tap usually works because bridge itself can make ARP reply message instead of tap device. 
It is default network interface behavior in Linux. When multiple interfaces attached to same host and they are in the same subnet, neighboring network interface can make ARP reply message instead of the destined network interface. 

But, tap cannot reply to ARP if we are not using linux bridge nor the bridge does not knows the neighbor mac/ipv4.

This feature is necessary for inter-controller communication when tap is attached to openvswitch. 
