### PR TITLE
Broadcast MAC learning for TinCan for DHCP

### DIFF
--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -368,7 +368,7 @@ peerlist_add_p(const char *id, const char *dest_ipv4, const char *dest_ipv6,
 // Associate mac address with TinCan peer.
 // Fill up MAC address in peer and make index for mac as key and peer as value
 int
-mac_add(const unsigned char * ipop_buf)
+mac_add(const unsigned char * ipop_buf, int mac_offset)
 {
     int id_key_length = ID_SIZE*2+1;
     char id_key [id_key_length];
@@ -383,8 +383,8 @@ mac_add(const unsigned char * ipop_buf)
     int i;
     long long key = 0;
     for(i=0;i<6;i++) {
-        *(peer->mac)=*(ipop_buf+62+i);
-        key += (long long) *(ipop_buf+62+i) << 8*i;
+        *(peer->mac)=*(ipop_buf+mac_offset+i);
+        key += (long long) *(ipop_buf+mac_offset+i) << 8*i;
     }
     khint_t k = kh_put(64, mac_table, key, &ret);
     if (ret == -1) {
@@ -392,6 +392,19 @@ mac_add(const unsigned char * ipop_buf)
     }
     kh_value(mac_table, k) = peer;
     return 0;
+}
+
+// Associate TinCan link with Mac address of sender hareward address of ARP
+int
+arp_sha_mac_add(const unsigned char * ipop_buf) {
+    mac_add(ipop_buf, 62);
+}
+
+// Associate TinCan link with Mac address of sender hareward address of 
+// Ethernet frame
+int
+source_mac_add(const unsigned char * ipop_buf) {
+    mac_add(ipop_buf, 46);
 }
 
 /**

--- a/src/peerlist.h
+++ b/src/peerlist.h
@@ -107,7 +107,7 @@ void increase_id_table_itr();
 int is_id_exist();
 void retrieve_id(const char ** key);
 void iterate_id_table();
-int mac_add(const unsigned char * ipop_buf);
+int mac_add(const unsigned char * ipop_buf, int mac_offset);
 
 #if defined(LINUX) || defined(ANDROID)
 int override_base_ipv4_addr_p(const char *ipv4);

--- a/src/translator.c
+++ b/src/translator.c
@@ -260,7 +260,7 @@ create_arp_response(unsigned char *buf)
 int
 create_arp_response_sw(unsigned char *buf, unsigned char *mac, unsigned char *my_ip4)
 {
-    memcpy(buf + 32, buf, 6);
+    memcpy(buf + 32, buf+6, 6);
     memcpy(buf + 38, buf + 28, 4);
     memcpy(buf, buf + 6, 6);
     memcpy(buf + 6, mac, 6);


### PR DESCRIPTION
To Make DHCP working, it learns mac when it gets broadcast mac address.
It does not specifically check DHCP protocol, but when the tap sees the
L2 broadcast frame (destination mac ffffff), it adds the source mac address
to TinCan link.
