### PR TITLE
ICC API are added

### DIFF
--- a/src/translator.c
+++ b/src/translator.c
@@ -295,3 +295,10 @@ is_my_ip4(const unsigned char *buf, const unsigned char *my_ip4)
   return buf[38] == my_ip4[0] && buf[39] == my_ip4[1] &&
          buf[40] == my_ip4[2] && buf[41] == my_ip4[3];
 }
+
+int
+is_icc(const unsigned char *buf)
+{
+  return buf[40] == 0x00 && buf[41] == 0x69 && buf[42] == 0x70 &&
+         buf[43] == 0x6f && buf[44] == 0x70;
+}

--- a/src/translator.h
+++ b/src/translator.h
@@ -48,7 +48,9 @@ int is_arp_req(const unsigned char *buf);
 
 int is_arp_resp(const unsigned char *buf);
 
-int is_my_ip4(const unsigned char*buf, const unsigned char *my_ip4);
+int is_my_ip4(const unsigned char *buf, const unsigned char *my_ip4);
+
+int is_icc(const unsigned char * buf);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Previous ICC(inte-controller communication) has some problem working with switchmode. When IPOP is non-switchmode, it works as layer3 device and interact with O/S network stack as a layer3 device. So that we could open UDP or TCP socket on this ipop tap device. But after we attach tap device to layer 2 device(linux bridge or openvswitch), ipop renounce its layer 3 features and lost interaction with O/S network stack. For example, ARP reply message or ICMP Ping reply are not understood by O/S network stack. Those messages are just inside the bridge network itself. 

In this new ICC, we use TinCan link directly to send message between controllers. 

The message header from Controller to tincan is as below.

```
| 1 byte IPOP version field | 1 byte IPOP message type field | 20 byte source UID field | 20 byte destination uid field | 6 byte destination MAC address field |...
```

We use source uid and destination uid as an identifier for each controller node. 
We use destinatoin mac address as 00-69-70-6f-70-03 for ICC control message and  00-69-70-6f-70-04 for ICC packet message.  69-70-6f-70 is the ascii code for i-p-o-p and this address range is reserved field by mac protocol. 

The message header from source tincan to destination tincan is as below

```
| 20 byte source UID field | 20 byte destination uid field | 6 byte destination MAC address field |...
```

In the receiving end, receiving thread checks MAC field and if its ICC then nullities source and destination uid(for implementation convenience) then pass to controller. 
