### PR TITLE
remove several implicit casting

### DIFF
--- a/src/packetio.c
+++ b/src/packetio.c
@@ -99,14 +99,19 @@ ipop_send_thread(void *data)
         if (opts->switchmode) {
 
             // Check whether target of ARP request message is tap itself
-            if (is_arp_req(buf) && is_my_ip4(buf, opts->my_ip4)) {
-                create_arp_response_sw(buf, opts->mac, opts->my_ip4);
+            if (is_arp_req(buf) &&
+                is_my_ip4(buf, (const unsigned char *) opts->my_ip4)) {
+                create_arp_response_sw(buf, (unsigned char * ) opts->mac, 
+                                       (unsigned char *) opts->my_ip4);
                 // Write back ARP reply to tap device
 #if defined(LINUX) || defined(ANDROID)
                 int r = write(tap, buf, rcount);
 #elif defined(WIN32)
                 int r = write_tap(win32_tap, (char *)buf, rcount);
 #endif
+                if (r < 0) {
+                    fprintf(stderr, "write to tap failed\n");
+                }
             }
 
             /* If the frame is broadcast message, it sends the frame to
@@ -332,7 +337,7 @@ ipop_recv_thread(void *data)
         // ARP request target the tap of myself. It create ARP reply and sends
         // back the message back to the IPOP link it comes from.
         if (is_arp_req(buf) && (opts->switchmode == 1) &&
-            is_my_ip4(buf, opts->my_ip4)) {
+            is_my_ip4(buf, (const unsigned char *) opts->my_ip4)) {
 
             // Swaps source and destination UID (IPOP link identifier)
             // so that the ARP reply message goes back to source
@@ -341,7 +346,8 @@ ipop_recv_thread(void *data)
             memcpy(ipop_buf, ipop_buf+ID_SIZE, ID_SIZE);
             memcpy(ipop_buf + ID_SIZE, temp, ID_SIZE);
 
-            create_arp_response_sw(buf, opts->mac, opts->my_ip4);
+            create_arp_response_sw(buf, (unsigned char *) opts->mac,
+                                   (unsigned char *) opts->my_ip4);
 
             if (opts->send_func != NULL) {
                 if (opts->send_func((const char*)ipop_buf,

--- a/src/peerlist.c
+++ b/src/peerlist.c
@@ -397,14 +397,14 @@ mac_add(const unsigned char * ipop_buf, int mac_offset)
 // Associate TinCan link with Mac address of sender hareward address of ARP
 int
 arp_sha_mac_add(const unsigned char * ipop_buf) {
-    mac_add(ipop_buf, 62);
+    return mac_add(ipop_buf, 62);
 }
 
 // Associate TinCan link with Mac address of sender hareward address of 
 // Ethernet frame
 int
 source_mac_add(const unsigned char * ipop_buf) {
-    mac_add(ipop_buf, 46);
+    return mac_add(ipop_buf, 46);
 }
 
 /**

--- a/src/peerlist.h
+++ b/src/peerlist.h
@@ -88,6 +88,8 @@ WIN32_EXPORT int peerlist_add_p(const char *id, const char *dest_ipv4,
                                 const char *dest_ipv6, const uint16_t port);
 WIN32_EXPORT int peerlist_add_by_uid(const char *id);
 #endif
+int arp_sha_mac_add(const unsigned char * ipop_buf);
+int source_mac_add(const unsigned char * ipop_buf);
 int peerlist_get_by_id(const char *id, struct peer_state **peer);
 int peerlist_get_by_ids(const char *id, struct peer_state **peer);
 int peerlist_get_by_local_ipv4_addr(struct in_addr *_local_ipv4_addr,

--- a/src/translator.h
+++ b/src/translator.h
@@ -42,6 +42,8 @@ int update_mac(unsigned char *buf, const char* mac);
 
 int create_arp_response(unsigned char *buf);
 
+int create_arp_response_sw(unsigned char *buf, unsigned char *mac, unsigned char *my_ip4);
+
 int is_nonunicast(const unsigned char *buf);
 
 int is_broadcast(const unsigned char *buf);


### PR DESCRIPTION
- removed several implicit casting. Since it makes compile error.
- several function is missing sinature in header file.
